### PR TITLE
Agregar submenus en la cabecera del sitio

### DIFF
--- a/pelicanconf_common.py
+++ b/pelicanconf_common.py
@@ -41,34 +41,34 @@ DIRECT_TEMPLATES = [
     "organizers",
     "jobs",
 ]
-MENUITEMS_NAVBAR = [
-    ("La ciudad", "/pages/granada.html"),
-    ("Organización", "/organizers.html"),
-]
+MENUITEMS_NAVBAR = {
+    "La ciudad": {"Granada": "/pages/granada.html"},
+    "Organización": {"Equipo": "/organizers.html"},
+}
 
 if ENABLED_SPEAKERS:
-    MENUITEMS_NAVBAR.append(tuple(("Ponentes", "/keynoters.html")))
+    MENUITEMS_NAVBAR["Ponentes"] = "/keynoters.html"
 
 if ENABLED_SPONSORSHIPS:
-    MENUITEMS_NAVBAR.append(tuple(("Patrocinios", "/sponsorship.html")))
+    MENUITEMS_NAVBAR["Patrocinios"] = "/sponsorship.html"
 
 if ENABLED_FINANCIAL_AID:
-    MENUITEMS_NAVBAR.append(tuple(("Becas", "/becas.html")))
+    MENUITEMS_NAVBAR["Becas"] = "/becas.html"
 
 if ENABLED_SCHEDULE:
-    MENUITEMS_NAVBAR.append(tuple(("Horario", "/schedule.html")))
+    MENUITEMS_NAVBAR["Horario"] = "/schedule.html"
 
 if ENABLED_GALLERY:
-    MENUITEMS_NAVBAR.append(tuple(("Galería", "/gallery.html")))
+    MENUITEMS_NAVBAR["La ciudad"]["Galería"] = "/gallery.html"
 
 if ENABLED_PAST_EDITIONS:
-    MENUITEMS_NAVBAR.append(tuple(("Ediciones pasadas", "/past_editions.html")))
+    MENUITEMS_NAVBAR["Organización"]["Ediciones pasadas"] = "/past_editions.html"
 
 if ENABLED_JOBS:
-    MENUITEMS_NAVBAR.append(tuple(("Ofertas de trabajo", "/jobs.html")))
+    MENUITEMS_NAVBAR["Ofertas de trabajo"] = "/jobs.html"
 
 if ENABLED_BLOG:
-    MENUITEMS_NAVBAR.append(tuple(("Blog", "/blog.html")))
+    MENUITEMS_NAVBAR["Blog"] = "/blog.html"
 
 
 NAVBAR_STYLE = "is-primary"

--- a/theme/static/scss/style.scss
+++ b/theme/static/scss/style.scss
@@ -14,6 +14,7 @@ $dark--medium: rgb(20, 20, 20);
 
 $grey--ligth:#f8f6f6;
 $grey--medium: #e5e0de;
+$burgundy: #290a0f;
 
 
 @import url('https://fonts.googleapis.com/css2?family=Arvo:wght@700&family=Montserrat&display=swap');
@@ -33,6 +34,17 @@ $grey--medium: #e5e0de;
 .navbar {
   background-color: $primary !important;
   box-shadow: 0 2px 4px 0 rgba(0,0,0,.4);
+}
+
+.navbar-item {
+  background-color: $primary !important;
+}
+.navbar-item:hover {
+  background-color: $burgundy !important;
+}
+
+.navbar-dropdown {
+  background-color: $primary !important;
 }
 
 h1,

--- a/theme/templates/_includes/navbar.html
+++ b/theme/templates/_includes/navbar.html
@@ -15,10 +15,25 @@
                 </div>
                 <div id="navbarMenuHeroA" class="navbar-menu">
                     <div class="navbar-end">
-                        {% for item, link in MENUITEMS_NAVBAR %}
+                        {% for item, link in MENUITEMS_NAVBAR.items() %}
+                            {% if link is string %}
                         <a class="navbar-item" href="{{ SITEURL }}{{ link }}">
                             {{ item }}
                         </a>
+                            {% elif link is mapping %}
+                        <div class="navbar-item has-dropdown is-hoverable">
+                            <a class="navbar-link">
+                                {{ item }}
+                            </a>
+                            <div class="navbar-dropdown">
+                            {% for subitem, url in link.items() %}
+                                <a class="navbar-item" href="{{ SITEURL }}{{ url }}">
+                                    {{ subitem }}
+                                </a>
+                            {% endfor %}
+                            </div>
+                        </div>
+                            {% endif %}
                         {% endfor %}
                     </div>
                 </div>


### PR DESCRIPTION
Al tener muchos enlaces en la cabecera, perdemos la oportunidad
de resaltar las temáticas más importantes.

Al agregar la opción de sumenus podemos agrupar algunos temas,
para tener una navegación más simple

(Se agrega video)

https://user-images.githubusercontent.com/177982/180438557-7c3e89f8-fe89-4996-84a7-7be641d7c067.mp4

