### PR TITLE
Quitar Horario del menú y agregar Código de Conducta

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,8 +97,9 @@ Para facilitar el trabajo contamos con el archivo **pelicanconf_flags.py** donde
 | ENABLED_SPEAKERS          | Habilita pantalla de ponentes.                               |
 | ENABLED_SPONSORSHIPS      | Habilita bloque con todos los patrocinadores.                |
 | ENABLED_CALL_FOR_SPONSORS | Habilita bloque con llamamiento a patrocinadores             |
-| ENABLED_SCHEDULE          | Habilita la vista del calendario del evento.                 |
+| ENABLED_TIMETABLE         | Habilita la vista del calendario del evento.                 |
 | ENABLED_BLOG              | Habilita la funcionalidad de blog de contenidos de la web.   |
+| ENABLED_SCHEDULE_INFO     | Habilita la vista del la información del programa en el sitio principal |
 
 ## Despliegue y puesta en producción de la web 🚀
 

--- a/pelicanconf_common.py
+++ b/pelicanconf_common.py
@@ -44,6 +44,7 @@ DIRECT_TEMPLATES = [
 MENUITEMS_NAVBAR = {
     "La ciudad": {"Granada": "/pages/granada.html"},
     "Organización": {"Equipo": "/organizers.html"},
+    "Código de Conducta": "/pages/code-of-conduct.html",
 }
 
 if ENABLED_SPEAKERS:
@@ -55,7 +56,7 @@ if ENABLED_SPONSORSHIPS:
 if ENABLED_FINANCIAL_AID:
     MENUITEMS_NAVBAR["Becas"] = "/becas.html"
 
-if ENABLED_SCHEDULE:
+if ENABLED_TIMETABLE:
     MENUITEMS_NAVBAR["Horario"] = "/schedule.html"
 
 if ENABLED_GALLERY:

--- a/pelicanconf_flags.py
+++ b/pelicanconf_flags.py
@@ -52,5 +52,5 @@ ENABLED_TIMELINE = True
 # Habilita página de ofertas de trabajo
 ENABLED_JOBS = True
 
-# Habilita la sección del programa
-ENABLED_SCHEDULE = True
+# Habilita la sección del programa en la página principal
+ENABLED_SCHEDULE_INFO = True

--- a/theme/templates/index.html
+++ b/theme/templates/index.html
@@ -43,7 +43,7 @@
 					{% include "_includes/index/call_for_papers.html" %}
 				{% endif %}
 
-				{% if ENABLED_SCHEDULE %}
+				{% if ENABLED_SCHEDULE_INFO %}
 					{% include "_includes/index/schedule.html" %}
 				{% endif %}
 


### PR DESCRIPTION
Se quita temporalmente el Horario del menú,
pues aún no está publicado.

Existió un problema con PRs pasados, donde se utilizó erroneamente
la variable ENABLED_SCHEDULE para la información del sitio principal
que sobreescribió la opción de la página con el programa.
Se solucionó con otra variable.

Además se agrega el código de conducta al menú, pues no tenía
visibilidad al final del sitio web.