### PR TITLE
Add sponsors to schedule page

### DIFF
--- a/pelicanconf_event_sponsors.py
+++ b/pelicanconf_event_sponsors.py
@@ -6,6 +6,7 @@ SPONSORS = [
         "level_name": "keystone",
         "title": "Keystone 🏆",
         "size": "270px",
+        "size_schedule": "500px",
         "order": 1,
         "members": [
             {
@@ -24,6 +25,7 @@ SPONSORS = [
         "level_name": "diamond",
         "title": "Diamante 💎",
         "size": "250px",
+        "size_schedule": "400px",
         "order": 2,
         "members": [
             {
@@ -72,6 +74,7 @@ SPONSORS = [
         "level_name": "platinum",
         "title": "Platino 💽",
         "size": "210px",
+        "size_schedule": "200px",
         "order": 3,
         "members": [
             {
@@ -115,6 +118,7 @@ SPONSORS = [
         "level_name": "gold",
         "title": "Oro 📀",
         "size": "180px",
+        "size_schedule": "200px",
         "order": 4,
         "members": [
             {

--- a/theme/templates/schedule.html
+++ b/theme/templates/schedule.html
@@ -29,4 +29,25 @@
     <a download target="_blank" class="button is-medium button is-link" href="https://charlas.2022.es.pycon.org/pycones2022/schedule/export/schedule.xcal">Descargar XCal</a>
 </div>
 
+<section class="section">
+  <div class="container">
+{% for sponsor in SPONSORS %}
+    {% if sponsor['members'] and sponsor['level_name'] not in ['silver', 'friend'] %}
+        <h3 class="title is-3">{{ sponsor['title'] }}</h3>
+        <div class="sponsor_grid-container" style="grid-template-columns: repeat(auto-fill, minmax({{ sponsor['size_schedule'] }}, 1fr));">
+            {% for member in sponsor['members'] %}
+                <div class="sponsor_card">
+                    <a href="{{ member.url }}" target="_blank">
+                        <figure class="image is-4by3">
+                            <img src="{{SITEURL}}{{ member.photo }}" alt="{{ member.name }}">
+                        </figure>
+                    </a>
+                </div>
+            {% endfor %}
+        </div>
+    {% endif %}
+{% endfor %}
+  </div>
+</section>
+
 {% endblock content %}


### PR DESCRIPTION
This also introduces a new field on the SPONSOR pelican dictionary structure, `size_schedule` to increase the size of the logos on the schedule page.


![Screenshot 2022-08-17 at 17-17-42 PyConES 2022 GRX](https://user-images.githubusercontent.com/177982/185178308-d01636af-ae41-4ce9-b878-86ce76631fa3.png)