### PR TITLE
warning

### DIFF
--- a/pelicanconf_event.py
+++ b/pelicanconf_event.py
@@ -94,7 +94,7 @@ EVENT_TALKS = json.dumps(
 
 EVENT_WARNINGS = [
     {
-        "message": "El gran día ha llegado, a partir de las 14:30 el equipo estará preparado para acreditar a los asistente. Preparad vuestras entradas 🎟",
+        "message": "El gran día ha llegado, a partir de las 14:30 el equipo estará preparado para acreditar a los asistentes. Preparad vuestras entradas 🎟",
         "color": "is-info",  # "is-warning, is-success, is-danger,  is-info"
     }
 ]


### PR DESCRIPTION
- Trustyou jobs offers
- Trustyou jobs offers
- Quitar horario
- Agregar párrafo pronombres en CoC
- Agregar submenus en la cabecera del sitio
- Quitar Horario del menú y agregar Código de Conducta (#163)
- jobs
- disable nucleoo jobs
- Horario
- Horario
- jobs
- jobs
- splited pelicanconf_event
- Agregar sección Twitter
- Add sponsors to schedule page
- Change text about the schedule being beta
- Moved HolaLuz
- Add djangogirls workshop post
- Add Alight positions (#175)
- jobs
- Cathedral Software Salary ranges and novatec link change (#178)
- Cathedral changes (#180)
- Jobs 01092022 (#181)
- Updated brite logo
- Updated brite logo to 800x600 and white background
- Jobs 07092022 (#183)
- finn force job offers (#184)
- financial force has only one N so it can find the png
- nazaries jobs
- Actualizar texto entradas
- orbital ads jobs
- data dog jobs (#189)
- singular sponsorship started
- singular en png
- fix ratio singular logo and url (#192)
- Agrega Facultad Medicina UGR (#193)
- Agrega información reventa (#194)
- Agrega mapa conferencia
- Reemplazar Becas por Mapa en el menú
- mixed changes
- warning section
- warning section
- Disable publications
- Jobs
- Jobs
- Jobs
- Jobs
- warning
